### PR TITLE
updates for braggvector calibration

### DIFF
--- a/py4DSTEM/process/diskdetection/braggvectors.py
+++ b/py4DSTEM/process/diskdetection/braggvectors.py
@@ -51,13 +51,15 @@ class BraggVectors(Custom,BraggVectorMethods,Data):
         self,
         Rshape,
         Qshape,
-        name = 'braggvectors'
+        name = 'braggvectors',
+        verbose = True,
         ):
         Custom.__init__(self,name=name)
 
         self.Rshape = Rshape
         self.shape = self.Rshape
         self.Qshape = Qshape
+        self.verbose = verbose 
 
         self._v_uncal = PointListArray(
             dtype = [
@@ -197,7 +199,8 @@ class BraggVectors(Custom,BraggVectorMethods,Data):
             "pixel" : pixel,
             "rotate" : rotate,
         }
-
+        if self.verbose: 
+            print('current calstate: ', self.calstate)
         pass
 
 

--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -541,7 +541,7 @@ def show(
 
 
         # Create colormap with mask_color for bad values
-        cm = copy(plt.colormaps.get_cmap(cmap))
+        cm = copy(plt.cm.get_cmap(cmap))
         if mask_color=='empty':
             cm.set_bad(alpha=0)
         else:


### PR DESCRIPTION
[basics_03_calibration.ipynb.zip](https://github.com/bsavitzky/py4DSTEM/files/11391568/basics_03_calibration.ipynb.zip)

Hi Ben, 

I updated the tutorial notebook and have a few suggested changes for the braggvectors. The pixel size game is fun but I took it out for now to try to shorten the notebook :stuck_out_tongue_closed_eyes: 

I added a braggvectors method for the elliptical calibration, but I didn't add any decorator functions. Is that something we should add? 

~Steph 
